### PR TITLE
Set hosting sites for each env

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Deploy firebase to PR env
         uses: w9jds/firebase-action@master
         with:
-          args: deploy -P roster-pr --only hosting:project-dashboard-pr
+          args: deploy -P roster-pr --only hosting:project-dashboard-pull-request
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/firebase.json
+++ b/firebase.json
@@ -1,17 +1,49 @@
 {
-  "hosting": {
-    "site": "project-dashboard-pr",
-    "public": "./build",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ],
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
-    ]
-  }
+  "hosting": [
+    {
+      "site": "project-dashboard-pull-request",
+      "public": "./build",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    },
+    {
+      "site": "project-dashboard-test",
+      "public": "./build",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    },
+    {
+      "site": "devolution-project-dashboard",
+      "public": "./build",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Own site configurations for each Firebase project

usage PR: firebase deploy -P roster-pr --only hosting:project-dashboard-pull-request
test: firebase deploy -P roster-test-e37b6 --only hosting:project-dashboard-test
main: firebase deploy -P devolution-roster --only hosting:devolution-project-dashboard